### PR TITLE
Add UsersController with RESTful actions, routes, and request specs

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,49 @@
+class UsersController < ApplicationController
+  before_action :set_user, only: [:show, :update, :destroy]
+
+  # GET /users
+  def index
+    @users = User.all
+    render json: @users
+  end
+
+  # GET /users/:id
+  def show
+    render json: @user
+  end
+
+  # POST /users
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      render json: @user, status: :created
+    else
+      render json: { errors: @user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /users/:id
+  def update
+    if @user.update(user_params)
+      render json: @user
+    else
+      render json: { errors: @user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /users/:id
+  def destroy
+    @user.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:given_name, :family_name, :age)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
+  resources :users
+
   # Defines the root path route ("/")
   # root "posts#index"
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe "Users API", type: :request do
+  let!(:user) { User.create!(given_name: "Jane", family_name: "Doe", age: 30) }
+
+  it "lists users" do
+    get "/users"
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)).to be_an(Array)
+  end
+
+  it "shows a user" do
+    get "/users/#{user.id}"
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)["id"]).to eq(user.id)
+  end
+
+  it "creates a user" do
+    post "/users", params: { user: { given_name: "John", family_name: "Smith", age: 22 } }
+    expect(response).to have_http_status(:created)
+    expect(User.last.given_name).to eq("John")
+  end
+
+  it "updates a user" do
+    patch "/users/#{user.id}", params: { user: { family_name: "Roe" } }
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.family_name).to eq("Roe")
+  end
+
+  it "deletes a user" do
+    delete "/users/#{user.id}"
+    expect(response).to have_http_status(:no_content)
+    expect(User.where(id: user.id)).to be_empty
+  end
+end


### PR DESCRIPTION
## Why
We need to introduce user management endpoints to the API, enabling CRUD operations for users. This is foundational for user-related features and required for both internal and external integrations.

## What
- Added UsersController implementing standard RESTful actions (index, show, create, update, destroy).
- Updated routes to expose user endpoints.
- Added request specs for users to ensure endpoints work as expected and are covered by tests.
